### PR TITLE
Subject: Introduce configurable OpenAI model

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+OPENAI_MODEL=gpt-4o

--- a/src/worker.js
+++ b/src/worker.js
@@ -95,7 +95,7 @@ export default {
     });
 
     const parameters = {
-      model: "gpt-4o",
+      model: env.OPENAI_MODEL || "gpt-3.5-turbo",
       messages: [
         {
           role: "system",


### PR DESCRIPTION
Added an environment variable to make the OpenAI model configurable, defaulting to 'gpt-3.5-turbo' if not set. This change allows for more flexibility in choosing the model for development and testing, adapting to various requirements or preferences without altering the codebase. Ensuring compatibility across different OpenAI models could enhance the app's adaptability and testing strategies.

Reference: #N/A