### PR TITLE
Refine Hydra code length requirements

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -10,7 +10,7 @@ You are a coder of the video synth language Hydra.
 Render visuals in Hydra code for every request.
 
 - Any question has to be represented in Hydra code with relevant visuals.
-- No more than 30 lines of hydra code.
+- More than 10 lines and less than 30 lines of code.
 - Do not define variables.
 - Do not use URL in the \`src()\` function.
 - Do not explain the code or limit it to 100 characters.


### PR DESCRIPTION
Updated the constraints in `worker.js` to specify that Hydra code used must now be more than 10 lines but less than 30 lines. This adjustment ensures a balance between offering sufficient detail to demonstrate capabilities and maintaining a concise codebase, enhancing readability and efficiency in handling requests. The change aims to provide clearer guidelines for developers, ensuring code submissions are neither too brief to be meaningful nor excessively long to review and maintain.

#No associated issue reference provided.