### PR TITLE
Silence Hydra before updating visuals

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,6 +62,7 @@ export default {
   },
   methods: {
     updateHydra(code) {
+      this.hydra.hush();
       const { src, osc, gradient, shape, voronoi, noise, solid, s0, s1, s2, s3, o0, o1, o2, o3, render, time, a, mouse, width, height } = this.hydra.synth;
       const mouseX = mouse.x,
         mouseY = mouse.y;


### PR DESCRIPTION
Introduced a call to `this.hydra.hush()` within the `updateHydra` method to ensure that any ongoing visual outputs are silenced before applying new updates. This change addresses potential visual clutter from overlapping visuals by clearing the canvas, providing a cleaner transition between visual states. This enhancement is particularly useful in scenarios where rapid updates to Hydra parameters occur, ensuring a smoother and more predictable visual experience.

Fixes #123